### PR TITLE
Feature #170265295 : Create the Segment Card

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.7.2",
+    "@material-ui/icons": "^4.5.1",
     "connected-react-router": "^6.3.1",
     "history": "^4.7.2",
     "react": "^16.8.3",

--- a/src/app/components/CustomCardHeader/index.js
+++ b/src/app/components/CustomCardHeader/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+
+// This is where we place our Title and Description for the Analysis
+export default function CustomCardHeader() {
+    return (
+        <div>
+            <Typography variant="h6" component="h6" gutterBottom>
+                {/* Place the title here e.g Top Segment*/}
+                Top Segment
+            </Typography>
+            <Typography variant="subtitle1" component="h5">
+                {/* The description e.g Which is my top performing segment? */}
+                Which is my top performing segment?
+            </Typography>
+        </div>
+    );
+}

--- a/src/app/components/CustomLocationIcon/index.js
+++ b/src/app/components/CustomLocationIcon/index.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import {makeStyles} from '@material-ui/core/styles';
+import LocationOnIcon from '@material-ui/icons/LocationOn';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles({
+    locationDetails: {
+        float: "right",
+    },
+    locationIcon: {
+        float: "right",
+        paddingLeft: "0.6rem"
+    }
+});
+
+export default function CustomLocationIcon() {
+    const classes = useStyles();
+
+    return (
+        <span>
+            {/* For some reason the Icon needs to be declared first before the actual text
+            even though the text appears first (as it should) and the icon after when you load the page*/}
+            <LocationOnIcon className={classes.locationIcon} fontSize="large"/>
+           <Typography className={classes.locationDetails} variant="h6" display="inline" align="center">
+            {/*   Location value e.g Nairobi */}
+               Nairobi
+            </Typography>
+        </span>
+    );
+}

--- a/src/app/components/Dashboard/index.js
+++ b/src/app/components/Dashboard/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {makeStyles} from '@material-ui/core/styles';
-import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
+import SummaryCard from "../SummaryCard";
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -20,13 +20,16 @@ export default function Dashboard() {
 
     return (
         <div className={classes.root}>
-            <Grid container spacing={3}>
-                <Grid item xs={12} sm={6}>
-                    <Paper className={classes.paper}>xs=12 sm=6</Paper>
-                </Grid>
-                <Grid item xs={12} sm={6}>
-                    <Paper className={classes.paper}>xs=12 sm=6</Paper>
-                </Grid>
+            {/* We need the container for the gutters to the left and right */}
+            {/* We will also need a container for passing in all the required Summary data as an array (each element
+            is a card with summary e.g Top Segments
+            */}
+            <Grid container justify="space-between" spacing={3}>
+                <SummaryCard/>
+            </Grid>
+            {/*Container for the Table data*/}
+            <Grid container justify="space-between" spacing={3}>
+                <SummaryCard/>
             </Grid>
         </div>
     );

--- a/src/app/components/SummaryCard/index.js
+++ b/src/app/components/SummaryCard/index.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import {makeStyles} from '@material-ui/core/styles';
+import Card from '@material-ui/core/Card';
+import Typography from '@material-ui/core/Typography';
+import Divider from "@material-ui/core/Divider";
+import Grid from "@material-ui/core/Grid";
+import CustomLocationIcon from "../CustomLocationIcon";
+import CustomCardHeader from "../CustomCardHeader";
+import {ArrowDownward, ArrowUpward} from '@material-ui/icons';
+
+const useStyles = makeStyles({
+    card: {
+        minWidth: 275,
+    },
+    cardContent: {
+        padding: "0.4rem",
+        paddingTop: "0.5rem",
+        paddingBottom: "0.4rem",
+    },
+    title: {
+        fontSize: 14,
+    },
+    locationDetails: {
+        float: "right",
+    },
+    locationIcon: {
+        float: "right",
+        paddingLeft: "0.6rem"
+    },
+    trendDetailsContainer: {
+        marginTop: "0.5rem",
+    }
+});
+
+export default function SummaryCard() {
+    const classes = useStyles();
+    const trendType = 1;
+    let trendIcon = <ArrowDownward fontSize="small"/>;
+    if (trendType) {
+        trendIcon = <ArrowUpward fontSize="small"/>;
+    }
+
+    return (
+        <Grid item xs={12} sm={6}>
+            <div>
+                <CustomCardHeader/>
+                <Card className={classes.card}>
+                    <div className={classes.cardContent}>
+                        <div>
+                            <Typography variant="h4">
+                                <Typography variant="overline" display="inline">
+                                    {/* Currency */}
+                                    KES
+                                </Typography>
+                                {/* Amount */}
+                                678.9B
+                                <CustomLocationIcon/>
+                            </Typography>
+                        </div>
+                        <Divider/>
+                        <Typography className={classes.trendDetailsContainer} variant="caption" display="block">
+                            {/* Percentage Trend Value */}
+                            {trendIcon} 1.4% in the last 30 days
+                        </Typography>
+                    </div>
+                </Card>
+            </div>
+        </Grid>
+    );
+}

--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,7 @@
     />
     <title>Market Report</title>
     <link rel="manifest" href="assets/manifest.json"/>
-
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet"/>
     <!-- // TODO: performance killer. Find a better way of doing this -->
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" async>
     <link href="https://fonts.googleapis.com" rel="preconnect">

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -16,7 +16,7 @@ module.exports = {
     contentBase: './dist',
     hot: true,
     historyApiFallback: true,
-    host: '0.0.0.0',
+    host: 'localhost',
     port: 3005,
   },
   mode: "development",

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,6 +661,13 @@
     react-is "^16.8.0"
     react-transition-group "^4.3.0"
 
+"@material-ui/icons@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.5.1.tgz#6963bad139e938702ece85ca43067688018f04f8"
+  integrity sha512-YZ/BgJbXX4a0gOuKWb30mBaHaoXRqPanlePam83JQPZ/y4kl+3aW0Wv9tlR70hB5EGAkEJGW5m4ktJwMgxQAeA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/styles@^4.7.1":
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.7.1.tgz#48fa70f06441c35e301a9c4b6c825526a97b7a29"


### PR DESCRIPTION
#### What does this PR do?
- Add Segment Analysis card design

#### Description of Task to be completed?
- Create the segment card component
- Setup Material UI for a consistent UI standard

#### How should this be manually tested?
- Checkout to this branch `git checkout ft-design-summary-analysis-card-170265295`
- Start the server `yarn run dev`
- Navigate to `localhost:3005/`
- New landing page should display The Top Segment design

#### Any background context you want to provide?
N/A

#### What are the relevant Jira Ticket ID?
[#170265295 ](https://www.pivotaltracker.com/story/show/170265295 )

#### Screenshots
![image](https://user-images.githubusercontent.com/31648893/70804604-f1c2e300-1dc7-11ea-9afc-a8e315476613.png)